### PR TITLE
Calorie search

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-DB_USER=davehardy632
-DB_NAME_DEV=edamam_microservice_development
-DB_NAME_TEST=edamam_microservice_test
-DB_NAME_PROD=edamam_microservice_production

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -1,10 +1,11 @@
 var express = require("express");
+var sequelize = require("sequelize");
 var router = express.Router();
 var Recipe = require('../../../models').Recipe;
+const recipeAttributes = ["id", "foodType", "recipeName", "thumbnailImg", "ingredientNum", "prepTime", "ingredients", "calories", "url", "dietLabel", "healthLabel", "cautions", "fat", "carbs", "protein", "yield"]
 
 router.get("/food_search", async function(req, res, next) {
   foodType = req.url.split("=")[1]
-  recipeAttributes = ["id", "foodType", "recipeName", "thumbnailImg", "ingredientNum", "prepTime", "ingredients", "calories", "url", "dietLabel", "healthLabel", "cautions", "fat", "carbs", "protein", "yield"]
   if (!foodType) {
     noArgumentError = {"message": "Missing query parameter"}
     res.setHeader("Content-Type", "application/json");
@@ -22,10 +23,20 @@ router.get("/food_search", async function(req, res, next) {
   }
 });
 
+router.get("/calorie_search", async function(req, res) {
+  let calorieQuery = parseInt(req.query.q);
+  if (calorieQuery) {
+      recipes = await recipesByCalorieAmount(calorieQuery, recipeAttributes, 3)
+      res.setHeader("Content-Type", "application/json");
+      res.status(202).send(JSON.stringify(recipes));
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(406).send(JSON.stringify({error: "Invalid input."}));
+}});
+
 
 router.get("/servings_search", async function(req, res, next) {
   servingSize = parseInt(req.url.split("=")[1])
-  recipeAttributes = ["id", "foodType", "recipeName", "thumbnailImg", "ingredientNum", "prepTime", "ingredients", "calories", "url", "dietLabel", "healthLabel", "cautions", "fat", "carbs", "protein", "yield"]
   if (!servingSize) {
     noArgumentError = {"message": "Missing query parameter"}
     res.setHeader("Content-Type", "application/json");
@@ -49,6 +60,26 @@ let recipesByFoodType = async (food, attributes) => {
   let recipes = await Recipe.findAll({ where: {foodType: food}, attributes: attributes })
     .then(recipes => {
       return recipes;
+    })
+    .catch(error => {
+      return error
+    });
+  return recipes;
+}
+
+let recipesByCalorieAmount = async (calorieQuery, attributes, limit) => {
+  let recipes = await Recipe.findAll({
+      attributes: attributes,
+      order: sequelize.col('calories')
+    })
+    .then(recipes => {
+      let recipeStack = [];
+      recipes.forEach(recipe => {
+        recipeStack.push({recipe: recipe, difference: Math.abs(recipe.calories - calorieQuery)})
+      });
+      recipeStack.sort((a, b) => a.difference - b.difference);
+      let finalArray = recipeStack.slice(0,limit);
+      return finalArray.map(element => element["recipe"]["dataValues"]);
     })
     .catch(error => {
       return error

--- a/spec/api/v1/calorie_search.spec.js
+++ b/spec/api/v1/calorie_search.spec.js
@@ -1,0 +1,38 @@
+var request = require("supertest")
+var app = require("../../../app")
+const express = require("express");
+var router = express.Router();
+
+describe('api', () => {
+  describe ("api v1 calorie search path", () => {
+    test("should return a 202 status and all recipes", () => {
+      recipeValues =  [ 'id', 'foodType', 'recipeName', 'thumbnailImg', 'ingredientNum', 'prepTime', 'ingredients', 'calories', 'url', 'dietLabel', 'healthLabel', 'cautions', 'fat', 'carbs', 'protein', 'yield' ]
+      return request(app).get("/api/v1/recipes/calorie_search?q=1000")
+      .set('Accept', 'application/json')
+      .then(response => {
+        expect(response.statusCode).toBe(202);
+        expect(Object.keys(response.body).length).toEqual(3);
+        expect(Object.keys(response.body[0])).toEqual(recipeValues);
+        expect(Object.keys(response.body[2])).toEqual(recipeValues);
+      });
+    });
+
+    test("should return a 404 status and an error for missing parameter", () => {
+      return request(app).get("/api/v1/recipes/calorie_search")
+      .set('Accept', 'application/json')
+      .then(response => {
+        expect(response.statusCode).toBe(404);
+        expect(response.body).toEqual({"error": "Missing query parameter."});
+      });
+    });
+
+    test("should return a 404 status and error message for no matching recipes", () => {
+      return request(app).get("/api/v1/recipes/calorie_search?q=walnuts")
+      .set('Accept', 'application/json')
+      .then(response => {
+        expect(response.statusCode).toBe(406);
+        expect(response.body).toEqual({"error": "Invalid input."});
+      })
+    });
+  });
+});

--- a/spec/api/v1/calorie_search.spec.js
+++ b/spec/api/v1/calorie_search.spec.js
@@ -5,10 +5,9 @@ var router = express.Router();
 
 describe('api', () => {
   describe ("api v1 calorie search path", () => {
-    test("should return a 202 status and all recipes", () => {
+    test("should return a 202 status and three recipes", () => {
       recipeValues =  [ 'id', 'foodType', 'recipeName', 'thumbnailImg', 'ingredientNum', 'prepTime', 'ingredients', 'calories', 'url', 'dietLabel', 'healthLabel', 'cautions', 'fat', 'carbs', 'protein', 'yield' ]
       return request(app).get("/api/v1/recipes/calorie_search?q=1000")
-      .set('Accept', 'application/json')
       .then(response => {
         expect(response.statusCode).toBe(202);
         expect(Object.keys(response.body).length).toEqual(3);
@@ -17,18 +16,16 @@ describe('api', () => {
       });
     });
 
-    test("should return a 404 status and an error for missing parameter", () => {
+    test("should return a 406 status and an error for missing parameter", () => {
       return request(app).get("/api/v1/recipes/calorie_search")
-      .set('Accept', 'application/json')
       .then(response => {
-        expect(response.statusCode).toBe(404);
-        expect(response.body).toEqual({"error": "Missing query parameter."});
+        expect(response.statusCode).toBe(406);
+        expect(response.body).toEqual({"error": "Invalid input."});
       });
     });
 
-    test("should return a 404 status and error message for no matching recipes", () => {
+    test("should return a 406 status and error message for no matching recipes", () => {
       return request(app).get("/api/v1/recipes/calorie_search?q=walnuts")
-      .set('Accept', 'application/json')
       .then(response => {
         expect(response.statusCode).toBe(406);
         expect(response.body).toEqual({"error": "Invalid input."});


### PR DESCRIPTION
Add an endpoint to search for recipes that have a calorie count close to what was passed in the query parameter.
This endpoint accepts a get request to /api/v1/recipes/calorie_search, with a query parameter in the format of q=<number of calories>.
This endpoint will return the three recipes closest to the number passed in the parameter.
Add testing for both happy and sad paths.
Completes #32